### PR TITLE
Creates Container to Include Do Not Sell Info

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -25,6 +25,12 @@ footer {
             line-height: 2.2rem;
             letter-spacing: 2px;
         }
+
+        a,
+        a:visited {
+            color: white;
+            text-decoration: none;
+        }
     }
 }
 

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -31,6 +31,10 @@ footer {
             color: white;
             text-decoration: none;
         }
+
+        a:hover {
+            color: #7000ff;
+        }
     }
 }
 

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -3,19 +3,41 @@ footer {
     left: 0;
     bottom: 0; */
     width: 100%;
-    background-color: #000; 
+    background-color: #000;
     color: rgba(228, 228, 228, 1);
     text-align: center;
-    padding: 20px 0; 
+    padding: 20px 0;
+}
+
+.right-container {
+    ul {
+        list-style: none;
+        text-transform: uppercase;
+        text-align: right;
+        margin-right: 20px;
+
+        @media (min-width: 766px) {
+            text-align: right;
+            padding-left: 3.1rem;
+        }
+
+        li {
+            line-height: 2.2rem;
+            letter-spacing: 2px;
+        }
+    }
 }
 
 .social-links {
-    margin-bottom: .5rem; /* spacing between social links and copyright */
+    margin-bottom: .5rem;
+    /* spacing between social links and copyright */
 }
 
 .social-links a {
-    color: rgba(255, 255, 255, 0.8); /* icon color */
-    margin: 0 15px; /* spacing between icons */
+    color: rgba(255, 255, 255, 0.8);
+    /* icon color */
+    margin: 0 15px;
+    /* spacing between icons */
     font-size: .75rem;
 }
 

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -3,6 +3,13 @@ import './Footer.css';
 export default function Footer() {
     return (
         <footer>
+            <div className="right-container">
+                <ul>
+                    <li>Cookie Policy</li>
+                    <li>Privacy Policy</li>
+                    <li>Do Not Sell My Info</li>
+                </ul>
+            </div>
             <div className="social-links">
                 <a href="https://www.linkedin.com/company/spacelab-space/" target="_blank" rel="noopener noreferrer">
                     <i className="fab fa-linkedin fa-2x"></i>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -7,7 +7,13 @@ export default function Footer() {
                 <ul>
                     <li>Cookie Policy</li>
                     <li>Privacy Policy</li>
-                    <li>Do Not Sell My Info</li>
+                    <li>
+                        <a
+                            href="https://app.termly.io/notify/84244fc8-3ee5-4874-a964-b5102a61463c"
+                        >
+                            Do Not Sell My Info
+                        </a>
+                    </li>
                 </ul>
             </div>
             <div className="social-links">


### PR DESCRIPTION
Fixes #12 

Creates a container off to the right, much like the main spacelab site, housing "Do Not Sell Info" link. The same link from the main page has been used. 
Styling added to maintain white link, before and after clicked as well as neon purple hovering over. 

Before Img:
<img width="1468" alt="Screenshot 2024-04-18 at 1 38 24 PM" src="https://github.com/spacelabdev/fund_lab_force/assets/119828225/9f8c2a99-8425-48c7-bf88-2b2af1fc9e06">

After Img:
<img width="1465" alt="Screenshot 2024-04-18 at 1 38 56 PM" src="https://github.com/spacelabdev/fund_lab_force/assets/119828225/11b2d9da-ed89-4647-b0a2-b2a1ff5e4366">
<img width="1470" alt="Screenshot 2024-04-18 at 1 53 11 PM" src="https://github.com/spacelabdev/fund_lab_force/assets/119828225/ac28e081-1606-4643-9c03-aeb2bc755d83">

